### PR TITLE
Update README with correct repository navigation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ quickly turns messages in channels, DMs, or threads into a concise summary, boos
  ```
     git clone https://github.com/RocketChat/Apps.Chat.Summarize.git
  ```
+  <li>Navigate to the repository</li>
+    
+ ```
+    cd Apps.Chat.Summarize
+ ```
   
   <li>Install app dependencies</li>
   


### PR DESCRIPTION
## Issue(s)  
Closes #13 

## 📝 Summary  
This PR fixes a missing step in the README setup instructions where users need to navigate into the cloned repository before proceeding with installation.