### PR TITLE
fix: simplify supported models

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ quickly turns messages in channels, DMs, or threads into a concise summary, boos
   - If you are running server locally, `server_url` is http://localhost:3000. If you are running in another port, change the 3000 to the appropriate port.
   - `username` is the username of your admin user.
   - `password` is the password of your admin user.
+
+  <li> Open the App, by navigating to <i>Administration > Marketplace > Private Apps</i>. You should see the app listed there. Click on the App name to open the app.</li>
+
+  <li> Select the <i>Settings</i> tab and enter the LLM API Host URL. This is the URL of the LLM API you want to use. For example, if you are using OpenAI's GPT-3.5, the URL would be <a>https://api.openai.com</a> . If you are using a different LLM, enter the appropriate URL. Without any suffixes.</li>
+  <li> If the LLM provider requires an API key, enter the API key in the <i>API Key</i> field. This is required for authentication with the LLM provider. Local deployments usually don't require an API key.</li>
 </ol>
 
 <h2>How to use 💬</h2>

--- a/app/helpers/createTextCompletion.ts
+++ b/app/helpers/createTextCompletion.ts
@@ -77,7 +77,7 @@ export async function createTextCompletion(
 		const { choices } = response.data;
 		return choices[0].message.content;
 	} catch (error) {
-		app.getLogger().log(`Error in handleInternalLLM: ${error.message}`);
+		app.getLogger().log(`Error in createTextCompletion: ${error.message}`);
 		return 'Something went wrong. Please try again later.';
 	}
 }

--- a/app/helpers/createTextCompletion.ts
+++ b/app/helpers/createTextCompletion.ts
@@ -1,20 +1,13 @@
-import { IHttp, IHttpResponse, IRead } from '@rocket.chat/apps-engine/definition/accessors';
+import {
+	IHttp,
+	IHttpResponse,
+	IRead,
+} from '@rocket.chat/apps-engine/definition/accessors';
 import { IRoom } from '@rocket.chat/apps-engine/definition/rooms';
 import { IUser } from '@rocket.chat/apps-engine/definition/users';
 import { notifyMessage } from './notifyMessage';
 import { App } from '@rocket.chat/apps-engine/definition/App';
 import { SettingEnum } from '../settings/settings';
-
-interface OpenAIBody{
-    model: string;
-    messages: { role: string; content: string }[];
-    temperature: number;
-}
-interface GeminiBody{
-    model: string;
-    contents: { role: string; parts: { text: string }[] }[];
-}
-
 
 export async function createTextCompletion(
 	app: App,
@@ -25,26 +18,33 @@ export async function createTextCompletion(
 	prompt: string,
 	threadId?: string
 ): Promise<string> {
+	const model = await read
+		.getEnvironmentReader()
+		.getSettings()
+		.getValueById(SettingEnum.AI_MODEL_NAME);
 
-    let model: string;
-    const aiProvider = await app
-    .getAccessors()
-    .environmentReader.getSettings()
-    .getValueById(SettingEnum.AI_PROVIDER_OPTION_ID);
+	const host = await read
+		.getEnvironmentReader()
+		.getSettings()
+		.getValueById(SettingEnum.AI_MODEL_API_URL);
 
-    if(aiProvider === SettingEnum.ROCKETCHAT_INTERNAL_MODEL){
-        model = await app
-        .getAccessors()
-        .environmentReader.getSettings()
-        .getValueById(SettingEnum.MODEL_SELECTION)
-    }
-    else {
-        model = await app
-        .getAccessors()
-        .environmentReader.getSettings()
-        .getValueById(SettingEnum.AI_MODEL_NAME)
-    }
+	const apiKey = await read
+		.getEnvironmentReader()
+		.getSettings()
+		.getValueById(SettingEnum.AI_API_KEY);
 
+	if (!host) {
+		await notifyMessage(
+			room,
+			read,
+			user,
+			'Your Workspace AI is not set up properly. Please contact your administrator',
+			threadId
+		);
+		throw new Error(
+			'Your Workspace AI is not set up properly. Please contact your administrator'
+		);
+	}
 
 	const body = {
 		model,
@@ -57,225 +57,27 @@ export async function createTextCompletion(
 		temperature: 0,
 	};
 
-	const response = await handleResponse(body, app, http)
-
-	if (!response) {
-		await notifyMessage(
-			room,
-			read,
-			user,
-			'Something is wrong with AI. Please try again later',
-			threadId
+	try {
+		const response: IHttpResponse = await http.post(
+			`${host}/v1/chat/completions`,
+			{
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: `Bearer ${apiKey}`,
+				},
+				content: JSON.stringify(body),
+			}
 		);
-		throw new Error('Something is wrong with AI. Please try again later');
+
+		if (!response || !response.data) {
+			app.getLogger().log('No response data received from AI.');
+			return 'Something went wrong. Please try again later.';
+		}
+
+		const { choices } = response.data;
+		return choices[0].message.content;
+	} catch (error) {
+		app.getLogger().log(`Error in handleInternalLLM: ${error.message}`);
+		return 'Something went wrong. Please try again later.';
 	}
-
-    return response
-}
-
-async function handleResponse(
-    body: OpenAIBody,
-    app: App,
-    http: IHttp
-): Promise<string> {
-
-    const aiProvider = await app
-    .getAccessors()
-    .environmentReader.getSettings()
-    .getValueById(SettingEnum.AI_PROVIDER_OPTION_ID);
-
-    const apiKey = await app
-    .getAccessors()
-    .environmentReader.getSettings()
-    .getValueById(SettingEnum.AI_API_KEY);
-
-    const apiUrl = await app
-    .getAccessors()
-    .environmentReader.getSettings()
-    .getValueById(SettingEnum.AI_MODEL_API_URL);
-
-    switch (aiProvider) {
-        case SettingEnum.ROCKETCHAT_INTERNAL_MODEL:
-            return await handleInternalLLM(body, app, http);
-
-        case SettingEnum.SELF_HOSTED_MODEL:
-            return await handleSelfHostedModel(body, app, http, apiUrl);
-
-        case SettingEnum.OPEN_AI:
-            return await handleOpenAI(body, app, http, apiUrl, apiKey);
-
-        case SettingEnum.GEMINI:
-            return await handleGemini(body, app, http, apiKey);
-
-        default: {
-            const errorMsg = 'Error: AI provider is not configured correctly.';
-            app.getLogger().log(errorMsg);
-            return errorMsg;
-        }
-    }
-
-}
-
-
-async function handleInternalLLM(
-    body: object,
-    app : App,
-    http: IHttp,
-): Promise<string> {
-    try {
-
-        const modelname = await app
-		.getAccessors()
-		.environmentReader.getSettings()
-		.getValueById(SettingEnum.MODEL_SELECTION);
-
-        const response: IHttpResponse = await http.post(
-            `http://${modelname}/v1/chat/completions`,
-            {
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                content: JSON.stringify(body),
-            });
-
-            if (!response || !response.data) {
-                app.getLogger().log('No response data received from AI.');
-                return "Something went wrong. Please try again later.";
-            }
-
-            const { choices } = response.data;
-            return choices[0].message.content;
-
-    } catch (error) {
-            app
-            .getLogger()
-            .log(`Error in handleInternalLLM: ${error.message}`);
-        return "Something went wrong. Please try again later.";
-}
-}
-
-
-async function handleSelfHostedModel(
-    body: object,
-    app : App,
-    http: IHttp,
-    apiUrl: string,
-): Promise<string> {
-    try {
-
-        if (!apiUrl) {
-            app.getLogger().log('Self Hosted Model address not set.');
-                return "Your Workspace AI is not set up properly. Please contact your administrator"
-            }
-
-
-        const response: IHttpResponse = await http.post(
-            `${apiUrl}`,
-            {
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                content: JSON.stringify({
-                    ...body,
-                    stream: false
-                }),
-            },
-        );
-
-        if (!response || !response.data) {
-            app.getLogger().log('No response data received from AI.');
-            return "Something went wrong. Please try again later.";
-        }
-
-        const {message}= response.data
-        return message.content ;
-    } catch (error) {
-            app
-            .getLogger()
-            .log(`Error in handleSelfHostedModel: ${error.message}`);
-        return "Something went wrong. Please try again later.";
-}
-}
-
-async function handleOpenAI(
-    body: object,
-    app: App,
-    http: IHttp,
-    apiUrl: string,
-    apiKey: string,
-): Promise<string> {
-    try {
-
-        if (!apiKey || !apiUrl) {
-            app.getLogger().log('OpenAI settings not set properly.');
-            return "AI is not configured. Please contact your administrator to use this feature."
-        }
-
-        const response: IHttpResponse = await http.post(
-            `${apiUrl}`,
-            {
-                headers: {
-                    'Content-Type': 'application/json',
-                    Authorization: `Bearer ${apiKey}`,
-                },
-                content: JSON.stringify(body),
-            },
-        );
-
-        if (!response || !response.data) {
-            app.getLogger().log('No response data received from AI.');
-            return "Something went wrong. Please try again later.";
-        }
-
-        const { choices } = response.data;
-        return choices[0].message.content;
-    } catch (error) {
-        app.getLogger().log(`Error in handleOpenAI: ${error.message}`);
-        return "Something went wrong. Please try again later.";
-    }
-}
-
-async function handleGemini(
-    body: OpenAIBody,
-    app: App,
-    http: IHttp,
-    apiKey: string
-): Promise<string> {
-    try {
-        if (!apiKey) {
-            app.getLogger().log('Gemini API key is missing.');
-            return "AI is not configured. Please contact your administrator to use this feature.";
-        }
-
-        const geminiBody = convertToGeminiFormat(body);
-        const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/${geminiBody.model}:generateContent?key=${apiKey}`;
-        const response: IHttpResponse = await http.post(apiUrl, {
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            content: JSON.stringify(geminiBody),
-        });
-
-        if (!response || !response.data) {
-            app.getLogger().log('No response data received from Gemini.');
-            return "Something went wrong. Please try again later.";
-        }
-
-        const data = response.data;
-        return data.candidates[0].content.parts[0].text;
-    } catch (error) {
-        app.getLogger().log(`Error in handleGemini: ${error.message}`);
-        return "Something went wrong. Please try again later.";
-    }
-}
-
-function convertToGeminiFormat(openAIBody: OpenAIBody): GeminiBody {
-    const { model, messages } = openAIBody;
-
-    const contents = messages.map(({ role, content }) => ({
-        role: role === "system" ? "user" : role,
-        parts: [{ text: content }]
-    }));
-
-    return { model, contents};
 }

--- a/app/settings/settings.ts
+++ b/app/settings/settings.ts
@@ -4,93 +4,45 @@ import {
 } from '@rocket.chat/apps-engine/definition/settings';
 
 export enum SettingEnum {
-    // Core configuration for AI provider selection
-    AI_PROVIDER_OPTION_ID = 'ai-provider-option-id',
-    MODEL_SELECTION = 'model-selection',
-    // Supported AI providers
-    ROCKETCHAT_INTERNAL_MODEL = "internal-llm",
-    SELF_HOSTED_MODEL = 'self-hosted-model',
-    OPEN_AI = 'open-ai',
-    GEMINI = 'gemini',
-    // Specific model identifiers
-    LLAMA3_8B = 'llama3-8b',
-    MISTRAL_7B = 'mistral-7b',
-    // API connection parameters
-    AI_MODEL_API_URL = 'api-url',
-    AI_API_KEY = "api-key",
-    AI_MODEL_NAME = 'ai-model-name',
+	// Core configuration for AI provider selection
+	AI_PROVIDER_OPTION_ID = 'ai-provider-option-id',
+	MODEL_SELECTION = 'model-selection',
+	// API connection parameters
+	AI_MODEL_API_URL = 'api-url',
+	AI_API_KEY = 'api-key',
+	AI_MODEL_NAME = 'ai-model-name',
 }
 
-
 export const settings: ISetting[] = [
-      // AI Provider Configuration
-    {
-		id: SettingEnum.AI_PROVIDER_OPTION_ID,
-		type: SettingType.SELECT,
-		packageValue: SettingEnum.ROCKETCHAT_INTERNAL_MODEL,
+	//API Connection Settings
+	{
+		id: SettingEnum.AI_MODEL_API_URL,
+		type: SettingType.STRING,
+		packageValue: 'http://llama3-8b',
 		required: true,
 		public: false,
-		i18nLabel: 'Choose AI Provider',
-		values: [
-            {
-				key: SettingEnum.ROCKETCHAT_INTERNAL_MODEL, //Rocket.Chat's built-in LLM
-				i18nLabel: 'RocketChat Internal LLM',
-			},
-			{
-				key: SettingEnum.SELF_HOSTED_MODEL, //Self-hosted Ollama instance
-				i18nLabel: 'Ollama Self Hosted',
-			},
-			{
-				key: SettingEnum.OPEN_AI, //OpenAI-compatible API endpoints
-				i18nLabel: 'OpenAI & OpenAI API-Compatible LLM Provider (Together, Groq etc.)',
-			},
-			{
-				key: SettingEnum.GEMINI, //Google's Gemini Provider
-				i18nLabel: 'Gemini',
-			},
-		],
+		i18nLabel: 'Model API Host URL',
+		i18nDescription:
+			'Host URL for the AI model API. API calls will be made to `{settings_value}/v1/chat/completions`',
 	},
-    //Rocket.Chat Internal LLM Model Selection Specific Settings
 	{
-		id: SettingEnum.MODEL_SELECTION,
-		i18nLabel: 'Model selection',
-		i18nDescription: 'Required for RocketChat Internal LLM',
-		type: SettingType.SELECT,
-		values: [
-			{ key: SettingEnum.LLAMA3_8B, i18nLabel: 'Llama3 8B' },
-			{ key: SettingEnum.MISTRAL_7B, i18nLabel: 'Mistral 7B' },
-		],
-		required: false,
-		public: true,
-		packageValue: SettingEnum.LLAMA3_8B,
-	},
-    //API Connection Settings
-    {
-        id: SettingEnum.AI_MODEL_API_URL,
-        type: SettingType.STRING,
-        packageValue: '',
-        required: false,
-        public: false,
-        i18nLabel: 'AI Model API URL',
-        i18nDescription: 'Must be filled to use OpenAI and self-hosted models',
-    },
-    {
-        id: SettingEnum.AI_API_KEY,
-        type: SettingType.PASSWORD,
-        packageValue: '',
-        required: false,
-        public: false,
-        i18nLabel: 'AI API Key',
-        i18nDescription: 'Must be filled to use OpenAI and Gemini models',
-    },
-    {
 		id: SettingEnum.AI_MODEL_NAME,
 		type: SettingType.STRING,
-		packageValue: '',
-		required: true,
+		packageValue: 'llama3-8b',
+		required: false,
 		public: false,
 		i18nLabel: 'AI model name',
 	},
+	{
+		id: SettingEnum.AI_API_KEY,
+		type: SettingType.PASSWORD,
+		packageValue: 'sk_12c3456789abcdefg',
+		required: false,
+		public: false,
+		i18nLabel: 'API Key',
+		i18nDescription: 'API Key for the AI model',
+	},
+
 	{
 		id: 'add-ons',
 		i18nLabel: 'Summary add-ons',


### PR DESCRIPTION
Removes complexities introduced around the Models. #17 

> Why?

- Supporting different providers can become demanding as there are multiple inference providers. Better to keep BBYO OpenAI API-compatible, inference provider.
- Removed the dropdown for internal LLMs; LLMs could change, and the list is not dynamic.