### PR TITLE
feat: Added today and week based Filtering for AI Summarization feature

### DIFF
--- a/app/commands/SummarizeCommand.ts
+++ b/app/commands/SummarizeCommand.ts
@@ -26,9 +26,9 @@ import { IMessageRaw } from '@rocket.chat/apps-engine/definition/messages';
 export class SummarizeCommand implements ISlashCommand {
 	public command = 'chat-summary';
 	public i18nParamsExample =
-		'Summarize messages in a thread or channel [today|week]';
+		'Summarize messages in a thread or channel [today|week|unread]';
 	public i18nDescription =
-		'Generates a summary of recent messages. Use "today" or "week" to filter by time.';
+		'Generates a summary of recent messages. Use "today", "week", or "unread" to filter the messages';
 	public providesPreview = false;
 	private readonly app: App;
 

--- a/app/commands/SummarizeCommand.ts
+++ b/app/commands/SummarizeCommand.ts
@@ -278,7 +278,7 @@ export class SummarizeCommand implements ISlashCommand {
 		const messages: IMessageRaw[] = await read
 			.getRoomReader()
 			.getMessages(room.id, {
-				limit: Math.max(unreadCount || 100, 100),
+				limit: Math.min(unreadCount || 100, 100),
 				sort: { createdAt: 'asc' },
 			});
 


### PR DESCRIPTION
This PR adds filtering options to the AI Summarization feature, allowing users to summarize messages from:
1. Today
2. Week (current week, Past 7 days from today)

Used the same slash command to implement it, just user should give subcommand, I mean type the word next to it.
For Today -> `/chat-summary today`
For Week -> `/chat-summary week`

Closes #15 

I have tested it on safe.dev.rocket.chat as well

/chat-summary today: 

https://github.com/user-attachments/assets/29c042c3-7ea1-47b6-af72-d16ae009ee46




/chat-summary week: 
Since there were no messages in the general channel for the past 7 days, we got this response:

https://github.com/user-attachments/assets/93c7ce77-4f39-44d0-83b3-b88b102a396b

