### PR TITLE
Add templates for bug reports , feature requests and PR.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,31 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+labels: bug
+---
+
+
+### Description
+
+<!-- A clear and concise description of what the bug is. -->
+
+### Steps to Reproduce
+
+1. <!-- Go to '...' -->
+2. <!-- Click on '....' -->
+3. <!-- And so on... -->
+
+### Expected Behavior
+
+<!-- What you expect to happen -->
+
+### Actual Behavior
+
+<!-- What actually happens (include screenshots if applicable) -->
+
+
+### Additional Context
+
+<!-- Add any other context about the problem here. -->
+
+

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,31 @@
+---
+name: Feature Request
+about: Create a feature request for the project
+labels: enhancement
+---
+
+<!-- 
+Please use this template to propose new features or improvements.
+-->
+
+### As a developer
+
+<!-- Describe who is affected or would benefit from this feature (e.g., "as a developer") -->
+
+### I need to
+
+<!-- Describe what you need, for example: "I need to have an option to set an exact word limit on summaries" -->
+
+### So That
+
+<!-- Describe the benefit, e.g., "so that I can better control the output of summaries for my users." -->
+
+### Acceptance Criteria
+
+- [ ] TODO 1
+- [ ] TODO 2
+- [ ] TODO 3
+
+### Additional Context
+
+<!-- Add any other context or screenshots about the feature request here -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,60 @@
+<!-- 
+  This is a pull request template. You do not need to remove or uncomment the comments.
+  They won't show up in the final PR description.
+-->
+
+<!-- 
+  Your Pull Request title should start with one of the following tags:
+  
+  feat:      Adding a new feature
+  fix:       Bug fixes affecting the end-user
+  refactor:  A code change that doesn't alter behavior (cleanup, restructuring)
+  chore:     Small tasks or maintenance work
+  docs:      Documentation updates
+  ci:        Updating CI configuration
+  test:      Adding tests
+  i18n:      Updating translations
+  regression: Issues fixed during development that didn't affect production
+  
+-->
+
+<!-- Checklist: If you're unsure about any of these, feel free to ask!
+  - [ ] I have read the Contributing Guide.
+  - [ ] I have signed the CLA.
+  - [ ] Lint and unit tests pass locally with my changes.
+  - [ ] I have added tests that prove my fix/feature is effective (if applicable).
+  - [ ] I have added necessary documentation (if applicable).
+  - [ ] Any dependent changes have been merged and published in downstream modules.
+-->
+
+## Proposed Changes
+
+<!--
+  Describe the big picture of your changes here.
+  Include any relevant screenshots or videos to help illustrate your changes.
+  If this PR fixes an issue or resolves a feature request, please link to it below.
+-->
+
+## Issue(s) Addressed
+
+<!-- 
+  List the issues being closed or related to this PR.
+  Example: Closes #123
+-->
+
+## Steps to Test or Reproduce
+
+<!--
+  Provide clear steps to test your changes.
+  Example:
+  1. Go to the "Settings" page.
+  2. Click on "Save Changes".
+  3. Verify that the changes appear in the UI.
+-->
+
+## Further Comments
+
+<!--
+  Add any additional context or details about your changes.
+  Explain why you chose this approach and any alternatives you considered.
+-->


### PR DESCRIPTION
This PR adds two issue templates under `.github/ISSUE_TEMPLATE`:

- **bug_report.md:** For reporting bugs.
- **feature_request.md:** For suggesting new features. 

Also added template for Pull Request.

These templates aim to standardize issue reporting and make it easier to triage submissions.
