### PR TITLE
Feat : Customizable Summary Length/Detail Level

### DIFF
--- a/app/commands/SummarizeCommand.ts
+++ b/app/commands/SummarizeCommand.ts
@@ -13,6 +13,9 @@ import { notifyMessage } from '../helpers/notifyMessage';
 import { createTextCompletion } from '../helpers/createTextCompletion';
 import {
 	createAssignedTasksPrompt,
+	createBriefSummaryPrompt,
+	createBulletSummaryPrompt,
+	createDetailedSummaryPrompt,
 	createFileSummaryPrompt,
 	createFollowUpQuestionsPrompt,
 	createParticipantsSummaryPrompt,
@@ -51,17 +54,60 @@ export class SummarizeCommand implements ISlashCommand {
 		const room = context.getRoom();
 		const threadId = context.getThreadId();
 
-		const command = context.getArguments();
-		const [subcommand] = context.getArguments();
-		const filter = subcommand ? subcommand.toLowerCase() : '';
+		const args = context.getArguments();
+		let filter = '';
+		let summaryMode = 'default';
+		const filterKeywords = ['today', 'week', 'unread', 'help'];
+		const summaryModes = ['brief', 'detailed', 'bullet'];
+
+		for (const arg of args) {
+			const lowerArg = arg.toLowerCase();
+			if (filterKeywords.includes(lowerArg)) {
+				filter = lowerArg;
+			} else if (summaryModes.includes(lowerArg)) {
+				summaryMode = lowerArg;
+			}
+		}
+
+		if (filter === 'help') {
+			if (args.join(' ') === 'help') {
+				await notifyMessage(room, read, user, WELCOME_MESSAGE, threadId);
+				await notifyMessage(
+					room,
+					read,
+					user,
+					FREQUENTLY_ASKED_QUESTIONS,
+					threadId
+				);
+				return;
+			}
+
+			args.shift();
+			const helpRequest = args.join(' ');
+			const prompt = createUserHelpPrompt(
+				FREQUENTLY_ASKED_QUESTIONS,
+				helpRequest
+			);
+			const helpResponse = await createTextCompletion(
+				this.app,
+				room,
+				read,
+				user,
+				http,
+				prompt,
+				threadId
+			);
+			await notifyMessage(room, read, user, helpResponse, threadId);
+			return;
+		}
 
 		let unreadCount: number | undefined;
 		let startDate: Date | undefined;
 		let usernames: string[] | undefined;
-		const anyMatchedUsername = false;
+		let anyMatchedUsername = false;
 		const now = new Date();
 
-		if (!subcommand) {
+		if (!filter || filter === '') {
 			startDate = undefined;
 		} else {
 			switch (filter) {
@@ -84,10 +130,8 @@ export class SummarizeCommand implements ISlashCommand {
 						.getUserReader()
 						.getUserUnreadMessageCount(user.id);
 					break;
-				case 'help':
-					break;
 				default:
-					usernames = command.map((name) => name.replace(/^@/, ''));
+					usernames = args.map((name) => name.replace(/^@/, ''));
 			}
 		}
 
@@ -103,41 +147,6 @@ export class SummarizeCommand implements ISlashCommand {
 			.getAccessors()
 			.environmentReader.getSettings()
 			.getValueById('x-user-id');
-
-		let helpResponse: string;
-		if (filter === 'help') {
-			if (subcommand === command.join(' ')) {
-				await notifyMessage(room, read, user, WELCOME_MESSAGE, threadId);
-				await notifyMessage(
-					room,
-					read,
-					user,
-					FREQUENTLY_ASKED_QUESTIONS,
-					threadId
-				);
-				return;
-			}
-
-			command.shift();
-			const helpRequest = command.join(' ');
-
-			const prompt = createUserHelpPrompt(
-				FREQUENTLY_ASKED_QUESTIONS,
-				helpRequest
-			);
-			helpResponse = await createTextCompletion(
-				this.app,
-				room,
-				read,
-				user,
-				http,
-				prompt,
-				threadId
-			);
-			await notifyMessage(room, read, user, helpResponse, threadId);
-			return;
-		}
-
 		let messages: string;
 		if (!threadId) {
 			messages = await this.getRoomMessages(
@@ -205,30 +214,30 @@ export class SummarizeCommand implements ISlashCommand {
 		// 	throw new Error('Prompt injection detected');
 		// }
 
-		let summary: string;
-		if (!threadId) {
-			const prompt = createSummaryPromptByTopics(messages);
-			summary = await createTextCompletion(
-				this.app,
-				room,
-				read,
-				user,
-				http,
-				prompt,
-				threadId
-			);
+		let summaryPrompt: string;
+		if (summaryMode === 'brief') {
+			summaryPrompt = createBriefSummaryPrompt(messages);
+		} else if (summaryMode === 'detailed') {
+			summaryPrompt = createDetailedSummaryPrompt(messages);
+		} else if (summaryMode === 'bullet') {
+			summaryPrompt = createBulletSummaryPrompt(messages);
 		} else {
-			const prompt = createSummaryPrompt(messages);
-			summary = await createTextCompletion(
-				this.app,
-				room,
-				read,
-				user,
-				http,
-				prompt,
-				threadId
-			);
+			if (!threadId) {
+				summaryPrompt = createSummaryPromptByTopics(messages);
+			} else {
+				summaryPrompt = createSummaryPrompt(messages);
+			}
 		}
+
+		const summary = await createTextCompletion(
+			this.app,
+			room,
+			read,
+			user,
+			http,
+			summaryPrompt,
+			threadId
+		);
 		await notifyMessage(room, read, user, summary, threadId);
 
 		if (addOns.includes('assigned-tasks')) {

--- a/app/constants/prompts.ts
+++ b/app/constants/prompts.ts
@@ -303,6 +303,43 @@ User Question ###
 {userQuestion}
 ###
 `;
+
+const BRIEF_SUMMARY_PROMPT = `Summarize the following dialogue in 1-2 short and simple sentences using as few words as possible. Mention specific persons.
+
+Dialogue: ###
+{dialogue}
+###
+
+Summary: `;
+
+export function createBriefSummaryPrompt(dialogue: string): string {
+	return BRIEF_SUMMARY_PROMPT.replace('{dialogue}', dialogue);
+}
+
+const DETAILED_SUMMARY_PROMPT = `Provide a detailed summary of the following conversation. Include key points, context, and conclusions in a concise paragraph. Mention the names of specific persons.
+
+Dialogue: ###
+{dialogue}
+###
+
+Summary: `;
+
+export function createDetailedSummaryPrompt(dialogue: string): string {
+	return DETAILED_SUMMARY_PROMPT.replace('{dialogue}', dialogue);
+}
+
+const BULLET_SUMMARY_PROMPT = `Summarize the following dialogue in bullet points. List key topics and messages discussed using clear bullet formatting. Mention specific persons where applicable.
+
+Dialogue: ###
+{dialogue}
+###
+
+Summary: `;
+
+export function createBulletSummaryPrompt(dialogue: string): string {
+	return BULLET_SUMMARY_PROMPT.replace('{dialogue}', dialogue);
+}
+
 export function createUserHelpPrompt(
 	FrequentlyAskedQuestions: string,
 	userQuestion: string


### PR DESCRIPTION
<!-- 
  This is a pull request template. You do not need to remove or uncomment the comments.
  They won't show up in the final PR description.
-->

<!-- 
  Your Pull Request title should start with one of the following tags:
  
  feat:      Adding a new feature
  fix:       Bug fixes affecting the end-user
  refactor:  A code change that doesn't alter behavior (cleanup, restructuring)
  chore:     Small tasks or maintenance work
  docs:      Documentation updates
  ci:        Updating CI configuration
  test:      Adding tests
  i18n:      Updating translations
  regression: Issues fixed during development that didn't affect production
  
-->

<!-- Checklist: If you're unsure about any of these, feel free to ask!
  - [x] I have read the Contributing Guide.
  - [x] I have signed the CLA.
  - [x] Lint and unit tests pass locally with my changes.
  - [x] I have added tests that prove my fix/feature is effective (if applicable).
  - [x] I have added necessary documentation (if applicable).
  - [x] Any dependent changes have been merged and published in downstream modules.
-->

## Proposed Changes

This PR introduces new feature to the Rocket.Chat AI Chat Summarizer app by supporting multiple summary modes. Users now have the flexibility to add summary style keywords (such as "brief", "detailed", or "bullet") in their `/chat-summary` commands. Based on the keyword provided, the app selects an appropriate prompt to generate a tailored summary output. This feature is implemented with minimal code changes that integrate seamlessly into the existing executor logic of the slash command.

**Key changes:**
- Modified command argument parsing to detect summary mode keywords.
- Integrated calls to new prompt functions corresponding to the summary modes (brief, detailed, and bullet).
- Retained existing functionality for filtering messages (e.g., filtering by “today”, “week”, “unread”, and help command handling) without altering the overall code structure.

## Issue(s) Addressed

Closes #<insert-issue-number-if-applicable>

## Steps to Test or Reproduce
In any Rocket.Chat channel or thread, use the command with one of the new mode keywords:
   - `/chat-summary brief`
   - `/chat-summary detailed`
   - `/chat-summary bullet`

## Further Comments

